### PR TITLE
Fixed wrong url on fork repo

### DIFF
--- a/plugin/fugitive_pagure.py
+++ b/plugin/fugitive_pagure.py
@@ -28,10 +28,9 @@ def is_fork(remote):
     return (token == 'forks')
 
 def remote2http(remote):
+    url = remote
     if is_fork(remote):
         url = remote.replace('forks', 'fork')
-    else:
-        url = remote
     url = url.rsplit(".git")[0]
     if remote.startswith("ssh://"):
         url = url.split("@", 1)[1]

--- a/plugin/fugitive_pagure.py
+++ b/plugin/fugitive_pagure.py
@@ -23,9 +23,15 @@ def is_pagure(remote):
     domains = ["pagure.io", "src.fedoraproject.org"]
     return any(d in remote for d in domains)
 
+def is_fork(remote):
+    token = remote.rsplit("/")[3]
+    return (token == 'forks')
 
 def remote2http(remote):
-    url = remote
+    if is_fork(remote):
+        url = remote.replace('forks', 'fork')
+    else:
+        url = remote
     url = url.rsplit(".git")[0]
     if remote.startswith("ssh://"):
         url = url.split("@", 1)[1]


### PR DESCRIPTION
Here is a fix to `:Gbrowse` when used on forked repo.
This is because Forked repo's Git URL has a slight different from its Web URL.

Here's an example:

**Git URL:** 
`ssh://git@pagure.io/forks/didiksupriadi41/fedora-docs/quick-docs.git`
**Web URL:** 
`https://pagure.io/fork/didiksupriadi41/fedora-docs/quick-docs`

**forks** and **fork**.