### PR TITLE
Fix replacement

### DIFF
--- a/plugin/fugitive_pagure.py
+++ b/plugin/fugitive_pagure.py
@@ -30,7 +30,7 @@ def is_fork(remote):
 def remote2http(remote):
     url = remote
     if is_fork(remote):
-        url = remote.replace('forks', 'fork')
+        url = remote.replace('/forks/', '/fork/', 1)
     url = url.rsplit(".git")[0]
     if remote.startswith("ssh://"):
         url = url.split("@", 1)[1]


### PR DESCRIPTION
Just realize that I did a mistake by replacing all occurrences of `forks` string to `fork` in the URL.

I think just replacing the first occurrence of `forks` should be enough.
What do you think?