### PR TITLE
Add markup file handler to support highlighting

### DIFF
--- a/plugin/fugitive_pagure.py
+++ b/plugin/fugitive_pagure.py
@@ -5,6 +5,8 @@ def pagure_url(path=None, remote=None, commit=None, line1=None, line2=None, **kw
         return ""
 
     url = "{remote}/{type}/{commit}/f/{path}"
+    if is_markup(path):
+        url += "?text=True"
     if line1 and line1 != "0":
         url += "#_{line1}"
     if line2 and line2 != "0" and line2 != line1:
@@ -26,6 +28,10 @@ def is_pagure(remote):
 def is_fork(remote):
     token = remote.rsplit("/")[3]
     return (token == 'forks')
+
+def is_markup(path):
+    ext = path[path.rfind("."):]
+    return ext in (".rst", ".mk", ".md", ".markdown")
 
 def remote2http(remote):
     url = remote

--- a/tests/test_pagure_fugitive.py
+++ b/tests/test_pagure_fugitive.py
@@ -40,3 +40,7 @@ class TestFugitivePagure(unittest.TestCase):
         opts["line2"] = 14
         expected = "https://pagure.io/copr/copr/blob/master/f/frontend/coprs_frontend/manage.py#_12-14"
         assert pagure_url(**opts) == expected
+
+        opts["path"] = "README.md"
+        expected = "https://pagure.io/copr/copr/blob/master/f/README.md?text=True#_12-14"
+        assert pagure_url(**opts) == expected


### PR DESCRIPTION
I found that highlighting in markup files (e.g. **.md**, **.rst** files) doesn't work since Pagure views them not as text by default.

Hence we need to add `?text=True` at the end of URL to make it work.

My reference for list of markup file types on Pagure is based on this statement:
https://pagure.io/pagure/blob/master/f/pagure/ui/repo.py#_587-589

Please have a look. :eyes: 